### PR TITLE
add picocsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,184 +50,191 @@ from the outside.
 | `∅`       | Empty list        |
 
 ## Unexpected results in Commons CSV
-| Input    | Flags | Commons CSV                 | Expected | Implemented as expected by                    |
-| -------- | ----- | --------------------------- | -------- | --------------------------------------------- |
-| `A,"B`   | —     | :boom: UncheckedIOException | `A↷B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity |
-| `"A,B`   | —     | :boom: UncheckedIOException | `A,B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity |
-| `"D"␣`   | —     | `D`                         | `D␣`     | FastCSV, Opencsv, SuperCSV                    |
-| `"A,B"␣` | —     | `A,B`                       | `A,B␣`   | FastCSV, SuperCSV                             |
-| `"D"z`   | —     | :boom: UncheckedIOException | `Dz`     | FastCSV, Opencsv, SuperCSV                    |
-| `"A,B"z` | —     | :boom: UncheckedIOException | `A,Bz`   | FastCSV, SuperCSV                             |
+| Input    | Flags | Commons CSV                 | Expected | Implemented as expected by                             |
+| -------- | ----- | --------------------------- | -------- | ------------------------------------------------------ |
+| `A,"B`   | —     | :boom: UncheckedIOException | `A↷B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity |
+| `"A,B`   | —     | :boom: UncheckedIOException | `A,B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity |
+| `"D"␣`   | —     | `D`                         | `D␣`     | FastCSV, Opencsv, picocsv, SuperCSV                    |
+| `"A,B"␣` | —     | `A,B`                       | `A,B␣`   | FastCSV, picocsv, SuperCSV                             |
+| `"D"z`   | —     | :boom: UncheckedIOException | `Dz`     | FastCSV, Opencsv, picocsv, SuperCSV                    |
+| `"A,B"z` | —     | :boom: UncheckedIOException | `A,Bz`   | FastCSV, picocsv, SuperCSV                             |
 
 ## Unexpected results in CSVeed
-| Input      | Flags | CSVeed              | Expected   | Implemented as expected by                                                                                  |
-| ---------- | ----- | ------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| `␣`        | —     | `◯`                 | `␣`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `␣,␣`      | —     | `◯↷◯`               | `␣↷␣`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `,␣`       | —     | `◯↷◯`               | `◯↷␣`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `␣D`       | —     | `D`                 | `␣D`       | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `␣D␣,␣D␣`  | —     | `D↷D`               | `␣D␣↷␣D␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `A,␊B`     | —     | :boom: CsvException | `A↷◯⏎B`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity                   |
-| `␣,`       | —     | `◯↷◯`               | `␣↷◯`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `␣,␊D`     | —     | :boom: CsvException | `␣↷◯⏎D`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity                   |
-| `D␊`       | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
-| `D␍`       | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV            |
-| `D␍␊`      | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV            |
-| `A,"B`     | —     | :boom: CsvException | `A↷B`      | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                               |
-| `A,B"`     | —     | :boom: CsvException | `A↷B"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `"A,B`     | —     | :boom: CsvException | `A,B`      | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                               |
-| `"A␍␊B"`   | —     | `A␍B`               | `A␍␊B`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `A␊B,C`    | —     | :boom: CsvException | `A⏎B↷C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity                   |
-| `A,B␊C`    | —     | :boom: CsvException | `A↷B⏎C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity                   |
-| `A␊;B,C␊D` | —     | :boom: CsvException | `A⏎;B↷C⏎D` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity                   |
-| `"D"␣`     | —     | `D`                 | `D␣`       | FastCSV, Opencsv, SuperCSV                                                                                  |
-| `"A,B"␣`   | —     | `A,B`               | `A,B␣`     | FastCSV, SuperCSV                                                                                           |
-| `␣"D"`     | —     | `D`                 | `␣"D"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `␣"D"␣`    | —     | `D`                 | `␣"D"␣`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `"D"z`     | —     | :boom: CsvException | `Dz`       | FastCSV, Opencsv, SuperCSV                                                                                  |
-| `"A,B"z`   | —     | :boom: CsvException | `A,Bz`     | FastCSV, SuperCSV                                                                                           |
-| `z"D"`     | —     | :boom: CsvException | `z"D"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `z"A,B"`   | —     | :boom: CsvException | `z"A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
-| `z"D"z`    | —     | :boom: CsvException | `z"D"z`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| Input      | Flags | CSVeed              | Expected   | Implemented as expected by                                                                                           |
+| ---------- | ----- | ------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| `␣`        | —     | `◯`                 | `␣`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `␣,␣`      | —     | `◯↷◯`               | `␣↷␣`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `,␣`       | —     | `◯↷◯`               | `◯↷␣`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `␣D`       | —     | `D`                 | `␣D`       | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `␣D␣,␣D␣`  | —     | `D↷D`               | `␣D␣↷␣D␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `A,␊B`     | —     | :boom: CsvException | `A↷◯⏎B`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity                   |
+| `␣,`       | —     | `◯↷◯`               | `␣↷◯`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `␣,␊D`     | —     | :boom: CsvException | `␣↷◯⏎D`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity                   |
+| `D␊`       | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `D␍`       | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV            |
+| `D␍␊`      | —     | `D⏎◯`               | `D`        | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV            |
+| `A,"B`     | —     | :boom: CsvException | `A↷B`      | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                               |
+| `A,B"`     | —     | :boom: CsvException | `A↷B"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `"A,B`     | —     | :boom: CsvException | `A,B`      | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                               |
+| `"A␍␊B"`   | —     | `A␍B`               | `A␍␊B`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `A␊B,C`    | —     | :boom: CsvException | `A⏎B↷C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity                   |
+| `A,B␊C`    | —     | :boom: CsvException | `A↷B⏎C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity                   |
+| `A␊;B,C␊D` | —     | :boom: CsvException | `A⏎;B↷C⏎D` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity                   |
+| `"D"␣`     | —     | `D`                 | `D␣`       | FastCSV, Opencsv, picocsv, SuperCSV                                                                                  |
+| `"A,B"␣`   | —     | `A,B`               | `A,B␣`     | FastCSV, picocsv, SuperCSV                                                                                           |
+| `␣"D"`     | —     | `D`                 | `␣"D"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `␣"D"␣`    | —     | `D`                 | `␣"D"␣`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `"D"z`     | —     | :boom: CsvException | `Dz`       | FastCSV, Opencsv, picocsv, SuperCSV                                                                                  |
+| `"A,B"z`   | —     | :boom: CsvException | `A,Bz`     | FastCSV, picocsv, SuperCSV                                                                                           |
+| `z"D"`     | —     | :boom: CsvException | `z"D"`     | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `z"A,B"`   | —     | :boom: CsvException | `z"A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
+| `z"D"z`    | —     | :boom: CsvException | `z"D"z`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity                    |
 
 ## Unexpected results in JacksonCSV
-| Input    | Flags | JacksonCSV                         | Expected | Implemented as expected by                    |
-| -------- | ----- | ---------------------------------- | -------- | --------------------------------------------- |
-| `A,"B`   | —     | :boom: RuntimeJsonMappingException | `A↷B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity |
-| `"A,B`   | —     | :boom: RuntimeJsonMappingException | `A,B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity |
-| `"D"␣`   | —     | `D`                                | `D␣`     | FastCSV, Opencsv, SuperCSV                    |
-| `"A,B"␣` | —     | `A,B`                              | `A,B␣`   | FastCSV, SuperCSV                             |
-| `"D"z`   | —     | :boom: RuntimeJsonMappingException | `Dz`     | FastCSV, Opencsv, SuperCSV                    |
-| `"A,B"z` | —     | :boom: RuntimeJsonMappingException | `A,Bz`   | FastCSV, SuperCSV                             |
+| Input    | Flags | JacksonCSV                         | Expected | Implemented as expected by                             |
+| -------- | ----- | ---------------------------------- | -------- | ------------------------------------------------------ |
+| `A,"B`   | —     | :boom: RuntimeJsonMappingException | `A↷B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity |
+| `"A,B`   | —     | :boom: RuntimeJsonMappingException | `A,B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity |
+| `"D"␣`   | —     | `D`                                | `D␣`     | FastCSV, Opencsv, picocsv, SuperCSV                    |
+| `"A,B"␣` | —     | `A,B`                              | `A,B␣`   | FastCSV, picocsv, SuperCSV                             |
+| `"D"z`   | —     | :boom: RuntimeJsonMappingException | `Dz`     | FastCSV, Opencsv, picocsv, SuperCSV                    |
+| `"A,B"z` | —     | :boom: RuntimeJsonMappingException | `A,Bz`   | FastCSV, picocsv, SuperCSV                             |
 
 ## Unexpected results in JavaCSV
-| Input    | Flags | JavaCSV | Expected | Implemented as expected by |
-| -------- | ----- | ------- | -------- | -------------------------- |
-| `"D"␣`   | —     | `D`     | `D␣`     | FastCSV, Opencsv, SuperCSV |
-| `"A,B"␣` | —     | `A,B`   | `A,B␣`   | FastCSV, SuperCSV          |
-| `"D"z`   | —     | `D`     | `Dz`     | FastCSV, Opencsv, SuperCSV |
-| `"A,B"z` | —     | `A,B`   | `A,Bz`   | FastCSV, SuperCSV          |
+| Input    | Flags | JavaCSV | Expected | Implemented as expected by          |
+| -------- | ----- | ------- | -------- | ----------------------------------- |
+| `"D"␣`   | —     | `D`     | `D␣`     | FastCSV, Opencsv, picocsv, SuperCSV |
+| `"A,B"␣` | —     | `A,B`   | `A,B␣`   | FastCSV, picocsv, SuperCSV          |
+| `"D"z`   | —     | `D`     | `Dz`     | FastCSV, Opencsv, picocsv, SuperCSV |
+| `"A,B"z` | —     | `A,B`   | `A,Bz`   | FastCSV, picocsv, SuperCSV          |
 
 ## Unexpected results in Opencsv
-| Input    | Flags | Opencsv                          | Expected | Implemented as expected by                                                                       |
-| -------- | ----- | -------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `A,"B`   | —     | :boom: CsvMalformedLineException | `A↷B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                    |
-| `A,B"`   | —     | :boom: CsvMalformedLineException | `A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `"A,B`   | —     | :boom: CsvMalformedLineException | `A,B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                    |
-| `"A␍B"`  | —     | `A␊B`                            | `A␍B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity |
-| `"A␍␊B"` | —     | `A␊B`                            | `A␍␊B`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `"A,B"␣` | —     | `A,B"␣`                          | `A,B␣`   | FastCSV, SuperCSV                                                                                |
-| `␣"D"`   | —     | `␣D`                             | `␣"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `␣"D"␣`  | —     | `␣D"␣`                           | `␣"D"␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `"A,B"z` | —     | `A,B"z`                          | `A,Bz`   | FastCSV, SuperCSV                                                                                |
-| `z"D"`   | —     | `zD`                             | `z"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `z"A,B"` | —     | `zA,B`                           | `z"A↷B"` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `z"D"z`  | —     | `zD"z`                           | `z"D"z`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| Input    | Flags | Opencsv                          | Expected | Implemented as expected by                                                                                |
+| -------- | ----- | -------------------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `A,"B`   | —     | :boom: CsvMalformedLineException | `A↷B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                    |
+| `A,B"`   | —     | :boom: CsvMalformedLineException | `A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `"A,B`   | —     | :boom: CsvMalformedLineException | `A,B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                    |
+| `"A␍B"`  | —     | `A␊B`                            | `A␍B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity |
+| `"A␍␊B"` | —     | `A␊B`                            | `A␍␊B`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `"A,B"␣` | —     | `A,B"␣`                          | `A,B␣`   | FastCSV, picocsv, SuperCSV                                                                                |
+| `␣"D"`   | —     | `␣D`                             | `␣"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `␣"D"␣`  | —     | `␣D"␣`                           | `␣"D"␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `"A,B"z` | —     | `A,B"z`                          | `A,Bz`   | FastCSV, picocsv, SuperCSV                                                                                |
+| `z"D"`   | —     | `zD`                             | `z"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `z"A,B"` | —     | `zA,B`                           | `z"A↷B"` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `z"D"z`  | —     | `zD"z`                           | `z"D"z`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+
+## Unexpected results in picocsv
+| Input | Flags | picocsv | Expected | Implemented as expected by                                                                                          |
+| ----- | ----- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `␊D`  | —     | `⏎D`    | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV, Univocity |
+| `␍D`  | —     | `⏎D`    | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV                              |
+| `␍␊D` | —     | `⏎D`    | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV            |
 
 ## Unexpected results in sesseltjonna-csv
-| Input      | Flags | sesseltjonna-csv           | Expected   | Implemented as expected by                                                                |
-| ---------- | ----- | -------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
-| `A,␊B`     | —     | :boom: CsvException        | `A↷◯⏎B`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity |
-| `␣,␊D`     | —     | :boom: CsvException        | `␣↷◯⏎D`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity |
-| `A␍B`      | —     | `A␍B`                      | `A⏎B`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV    |
-| `␍D`       | —     | `␍D`                       | `◯⏎D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV    |
-| `A,"B`     | —     | :boom: CsvBuilderException | `A↷B`      | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                             |
-| `"A,B`     | —     | :boom: CsvBuilderException | `A,B`      | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                             |
-| `A␊B,C`    | —     | `A⏎B,C`                    | `A⏎B↷C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity |
-| `A,B␊C`    | —     | :boom: CsvException        | `A↷B⏎C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity |
-| `A␊;B,C␊D` | —     | `A⏎;B,C⏎D`                 | `A⏎;B↷C⏎D` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV, Univocity |
-| `"D"␣`     | —     | `D`                        | `D␣`       | FastCSV, Opencsv, SuperCSV                                                                |
-| `"A,B"␣`   | —     | `A,B`                      | `A,B␣`     | FastCSV, SuperCSV                                                                         |
-| `"D"z`     | —     | `D`                        | `Dz`       | FastCSV, Opencsv, SuperCSV                                                                |
-| `"A,B"z`   | —     | `A,B`                      | `A,Bz`     | FastCSV, SuperCSV                                                                         |
+| Input      | Flags | sesseltjonna-csv           | Expected   | Implemented as expected by                                                                         |
+| ---------- | ----- | -------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `A,␊B`     | —     | :boom: CsvException        | `A↷◯⏎B`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity |
+| `␣,␊D`     | —     | :boom: CsvException        | `␣↷◯⏎D`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity |
+| `A␍B`      | —     | `A␍B`                      | `A⏎B`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV    |
+| `␍D`       | —     | `␍D`                       | `◯⏎D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV             |
+| `A,"B`     | —     | :boom: CsvBuilderException | `A↷B`      | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                             |
+| `"A,B`     | —     | :boom: CsvBuilderException | `A,B`      | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                             |
+| `A␊B,C`    | —     | `A⏎B,C`                    | `A⏎B↷C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity |
+| `A,B␊C`    | —     | :boom: CsvException        | `A↷B⏎C`    | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity |
+| `A␊;B,C␊D` | —     | `A⏎;B,C⏎D`                 | `A⏎;B↷C⏎D` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV, Univocity |
+| `"D"␣`     | —     | `D`                        | `D␣`       | FastCSV, Opencsv, picocsv, SuperCSV                                                                |
+| `"A,B"␣`   | —     | `A,B`                      | `A,B␣`     | FastCSV, picocsv, SuperCSV                                                                         |
+| `"D"z`     | —     | `D`                        | `Dz`       | FastCSV, Opencsv, picocsv, SuperCSV                                                                |
+| `"A,B"z`   | —     | `A,B`                      | `A,Bz`     | FastCSV, picocsv, SuperCSV                                                                         |
 
 ## Unexpected results in Simpleflatmapper
-| Input    | Flags | Simpleflatmapper | Expected | Implemented as expected by |
-| -------- | ----- | ---------------- | -------- | -------------------------- |
-| `"D"␣`   | —     | `D"␣`            | `D␣`     | FastCSV, Opencsv, SuperCSV |
-| `"A,B"␣` | —     | `A,B"␣`          | `A,B␣`   | FastCSV, SuperCSV          |
-| `"D"z`   | —     | `D"z`            | `Dz`     | FastCSV, Opencsv, SuperCSV |
-| `"A,B"z` | —     | `A,B"z`          | `A,Bz`   | FastCSV, SuperCSV          |
+| Input    | Flags | Simpleflatmapper | Expected | Implemented as expected by          |
+| -------- | ----- | ---------------- | -------- | ----------------------------------- |
+| `"D"␣`   | —     | `D"␣`            | `D␣`     | FastCSV, Opencsv, picocsv, SuperCSV |
+| `"A,B"␣` | —     | `A,B"␣`          | `A,B␣`   | FastCSV, picocsv, SuperCSV          |
+| `"D"z`   | —     | `D"z`            | `Dz`     | FastCSV, Opencsv, picocsv, SuperCSV |
+| `"A,B"z` | —     | `A,B"z`          | `A,Bz`   | FastCSV, picocsv, SuperCSV          |
 
 ## Unexpected results in SuperCSV
-| Input    | Flags | SuperCSV                 | Expected | Implemented as expected by                                                                       |
-| -------- | ----- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------ |
-| `A,"B`   | —     | :boom: SuperCsvException | `A↷B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                    |
-| `A,B"`   | —     | :boom: SuperCsvException | `A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `"A,B`   | —     | :boom: SuperCsvException | `A,B`    | FastCSV, JavaCSV, Simpleflatmapper, Univocity                                                    |
-| `"A␍B"`  | —     | `A␊B`                    | `A␍B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity |
-| `"A␍␊B"` | —     | `A␊B`                    | `A␍␊B`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `␣"D"`   | —     | `␣D`                     | `␣"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `␣"D"␣`  | —     | `␣D␣`                    | `␣"D"␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `z"D"`   | —     | `zD`                     | `z"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `z"A,B"` | —     | `zA,B`                   | `z"A↷B"` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
-| `z"D"z`  | —     | `zDz`                    | `z"D"z`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| Input    | Flags | SuperCSV                 | Expected | Implemented as expected by                                                                                |
+| -------- | ----- | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
+| `A,"B`   | —     | :boom: SuperCsvException | `A↷B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                    |
+| `A,B"`   | —     | :boom: SuperCsvException | `A↷B"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `"A,B`   | —     | :boom: SuperCsvException | `A,B`    | FastCSV, JavaCSV, picocsv, Simpleflatmapper, Univocity                                                    |
+| `"A␍B"`  | —     | `A␊B`                    | `A␍B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity |
+| `"A␍␊B"` | —     | `A␊B`                    | `A␍␊B`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `␣"D"`   | —     | `␣D`                     | `␣"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `␣"D"␣`  | —     | `␣D␣`                    | `␣"D"␣`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `z"D"`   | —     | `zD`                     | `z"D"`   | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `z"A,B"` | —     | `zA,B`                   | `z"A↷B"` | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
+| `z"D"z`  | —     | `zDz`                    | `z"D"z`  | Commons CSV, FastCSV, JacksonCSV, JavaCSV, picocsv, sesseltjonna-csv, Simpleflatmapper, Univocity         |
 
 ## Unexpected results in Univocity
-| Input    | Flags  | Univocity | Expected | Implemented as expected by                                                                               |
-| -------- | ------ | --------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `A␍B`    | —      | `A␍B`     | `A⏎B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV                   |
-| `D␍`     | —      | `D␍`      | `D`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV         |
-| `␍D`     | —      | `␍D`      | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV                   |
-| `␍D`     | `[SE]` | `␍D`      | `D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, SuperCSV                                              |
-| `A␍␊B`   | —      | `A␍⏎B`    | `A⏎B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV |
-| `D␍␊`    | —      | `D␍`      | `D`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV         |
-| `␍␊D`    | —      | `␍⏎D`     | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV |
-| `␍␊D`    | `[SE]` | `␍⏎D`     | `D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, SuperCSV                                              |
-| `"D"␣`   | —      | `D`       | `D␣`     | FastCSV, Opencsv, SuperCSV                                                                               |
-| `"A,B"␣` | —      | `A,B`     | `A,B␣`   | FastCSV, SuperCSV                                                                                        |
-| `"D"z`   | —      | `"D"z`    | `Dz`     | FastCSV, Opencsv, SuperCSV                                                                               |
-| `"A,B"z` | —      | `"A,B"z`  | `A,Bz`   | FastCSV, SuperCSV                                                                                        |
+| Input    | Flags  | Univocity | Expected | Implemented as expected by                                                                                        |
+| -------- | ------ | --------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `A␍B`    | —      | `A␍B`     | `A⏎B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, Simpleflatmapper, SuperCSV                   |
+| `D␍`     | —      | `D␍`      | `D`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV         |
+| `␍D`     | —      | `␍D`      | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, Simpleflatmapper, SuperCSV                            |
+| `␍D`     | `[SE]` | `␍D`      | `D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, picocsv, SuperCSV                                              |
+| `A␍␊B`   | —      | `A␍⏎B`    | `A⏎B`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV |
+| `D␍␊`    | —      | `D␍`      | `D`      | Commons CSV, FastCSV, JacksonCSV, JavaCSV, Opencsv, picocsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV         |
+| `␍␊D`    | —      | `␍⏎D`     | `◯⏎D`    | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, Opencsv, sesseltjonna-csv, Simpleflatmapper, SuperCSV          |
+| `␍␊D`    | `[SE]` | `␍⏎D`     | `D`      | Commons CSV, CSVeed, FastCSV, JacksonCSV, JavaCSV, picocsv, SuperCSV                                              |
+| `"D"␣`   | —      | `D`       | `D␣`     | FastCSV, Opencsv, picocsv, SuperCSV                                                                               |
+| `"A,B"␣` | —      | `A,B`     | `A,B␣`   | FastCSV, picocsv, SuperCSV                                                                                        |
+| `"D"z`   | —      | `"D"z`    | `Dz`     | FastCSV, Opencsv, picocsv, SuperCSV                                                                               |
+| `"A,B"z` | —      | `"A,B"z`  | `A,Bz`   | FastCSV, picocsv, SuperCSV                                                                                        |
 
 ## Big picture
-| Input      | Flags  | Expected   | Commons CSV        | CSVeed             | FastCSV            | JacksonCSV         | JavaCSV            | Opencsv            | sesseltjonna-csv   | Simpleflatmapper   | SuperCSV           | Univocity          |
-| ---------- | ------ | ---------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| `D`        | —      | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `D,D`      | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `,D`       | —      | `◯↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣`        | —      | `␣`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣,␣`      | —      | `␣↷␣`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `,␣`       | —      | `◯↷␣`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣D`       | —      | `␣D`       | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣D␣,␣D␣`  | —      | `␣D␣↷␣D␣`  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `D,`       | —      | `D↷◯`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `A,␊B`     | —      | `A↷◯⏎B`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣,`       | —      | `␣↷◯`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␣,␊D`     | —      | `␣↷◯⏎D`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `A␊B`      | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `D␊`       | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␊D`       | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `␊D`       | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: |
-| `A␍B`      | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| `D␍`       | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| `␍D`       | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| `␍D`       | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :x:                |
-| `A␍␊B`     | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| `D␍␊`      | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| `␍␊D`      | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| `␍␊D`      | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :x:                |
-| `"␣D␣"`    | —      | `␣D␣`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"D"`      | —      | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"D",D`    | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `D,"D"`    | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `A,"B`     | —      | `A↷B`      | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: |
-| `A,B"`     | —      | `A↷B"`     | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: |
-| `"A,B`     | —      | `A,B`      | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: |
-| `"""D"`    | —      | `"D`       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"D"""`    | —      | `D"`       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"A""B"`   | —      | `A"B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"A␊B"`    | —      | `A␊B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"A␍B"`    | —      | `A␍B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `"A␍␊B"`   | —      | `A␍␊B`     | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `A␊B,C`    | —      | `A⏎B↷C`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `A,B␊C`    | —      | `A↷B⏎C`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `A␊;B,C␊D` | —      | `A⏎;B↷C⏎D` | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `"D"␣`     | —      | `D␣`       | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
-| `"A,B"␣`   | —      | `A,B␣`     | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :x:                |
-| `␣"D"`     | —      | `␣"D"`     | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `␣"D"␣`    | —      | `␣"D"␣`    | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `"D"z`     | —      | `Dz`       | :boom:             | :boom:             | :white_check_mark: | :boom:             | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
-| `"A,B"z`   | —      | `A,Bz`     | :boom:             | :boom:             | :white_check_mark: | :boom:             | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :x:                |
-| `z"D"`     | —      | `z"D"`     | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `z"A,B"`   | —      | `z"A↷B"`   | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| `z"D"z`    | —      | `z"D"z`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| Input      | Flags  | Expected   | Commons CSV        | CSVeed             | FastCSV            | JacksonCSV         | JavaCSV            | Opencsv            | picocsv            | sesseltjonna-csv   | Simpleflatmapper   | SuperCSV           | Univocity          |
+| ---------- | ------ | ---------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| `D`        | —      | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `D,D`      | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `,D`       | —      | `◯↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣`        | —      | `␣`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣,␣`      | —      | `␣↷␣`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `,␣`       | —      | `◯↷␣`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣D`       | —      | `␣D`       | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣D␣,␣D␣`  | —      | `␣D␣↷␣D␣`  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `D,`       | —      | `D↷◯`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `A,␊B`     | —      | `A↷◯⏎B`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣,`       | —      | `␣↷◯`      | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␣,␊D`     | —      | `␣↷◯⏎D`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `A␊B`      | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `D␊`       | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␊D`       | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `␊D`       | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: |
+| `A␍B`      | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| `D␍`       | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `␍D`       | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| `␍D`       | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :x:                |
+| `A␍␊B`     | —      | `A⏎B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `D␍␊`      | —      | `D`        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `␍␊D`      | —      | `◯⏎D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `␍␊D`      | `[SE]` | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_minus_sign: | :white_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: | :x:                |
+| `"␣D␣"`    | —      | `␣D␣`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"D"`      | —      | `D`        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"D",D`    | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `D,"D"`    | —      | `D↷D`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `A,"B`     | —      | `A↷B`      | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: |
+| `A,B"`     | —      | `A↷B"`     | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: |
+| `"A,B`     | —      | `A,B`      | :boom:             | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: | :boom:             | :white_check_mark: |
+| `"""D"`    | —      | `"D`       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"D"""`    | —      | `D"`       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"A""B"`   | —      | `A"B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"A␊B"`    | —      | `A␊B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"A␍B"`    | —      | `A␍B`      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `"A␍␊B"`   | —      | `A␍␊B`     | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `A␊B,C`    | —      | `A⏎B↷C`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `A,B␊C`    | —      | `A↷B⏎C`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `A␊;B,C␊D` | —      | `A⏎;B↷C⏎D` | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `"D"␣`     | —      | `D␣`       | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
+| `"A,B"␣`   | —      | `A,B␣`     | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
+| `␣"D"`     | —      | `␣"D"`     | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `␣"D"␣`    | —      | `␣"D"␣`    | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `"D"z`     | —      | `Dz`       | :boom:             | :boom:             | :white_check_mark: | :boom:             | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
+| `"A,B"z`   | —      | `A,Bz`     | :boom:             | :boom:             | :white_check_mark: | :boom:             | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :white_check_mark: | :x:                |
+| `z"D"`     | —      | `z"D"`     | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `z"A,B"`   | —      | `z"A↷B"`   | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| `z"D"z`    | —      | `z"D"z`    | :white_check_mark: | :boom:             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,4 +30,5 @@ dependencies {
     implementation("org.simpleflatmapper:sfm-csv:8.2.3")
     implementation("org.csveed:csveed:0.7.5")
     implementation("org.slf4j:slf4j-nop:2.0.7")
+    implementation("com.github.nbbrd.picocsv:picocsv:2.2.2")
 }

--- a/src/main/java/comparison/Comparison.java
+++ b/src/main/java/comparison/Comparison.java
@@ -13,6 +13,7 @@ import comparison.impl.FastCsvImpl;
 import comparison.impl.JacksonCsvImpl;
 import comparison.impl.JavaCsvImpl;
 import comparison.impl.OpenCsvImpl;
+import comparison.impl.PicocsvImpl;
 import comparison.impl.SesseltjonnaCsvImpl;
 import comparison.impl.SfmCsvImpl;
 import comparison.impl.SuperCsvImpl;
@@ -28,6 +29,7 @@ public final class Comparison {
         new JacksonCsvImpl(),
         new JavaCsvImpl(),
         new OpenCsvImpl(),
+        new PicocsvImpl(),
         new SesseltjonnaCsvImpl(),
         new SfmCsvImpl(),
         new SuperCsvImpl(),

--- a/src/main/java/comparison/impl/PicocsvImpl.java
+++ b/src/main/java/comparison/impl/PicocsvImpl.java
@@ -1,0 +1,47 @@
+package comparison.impl;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import nbbrd.picocsv.Csv;
+
+public class PicocsvImpl implements CsvImpl {
+
+    @Override
+    public String getName() {
+        return "picocsv";
+    }
+
+    @Override
+    public List<String[]> readCsv(final String data, final boolean skipEmptyRows) throws Exception {
+        final List<String[]> rows = new ArrayList<>();
+
+        final Csv.Reader csv = Csv.Reader.of(Csv.Format.DEFAULT,
+                                             Csv.ReaderOptions.builder()
+                                                              .lenientSeparator(true)
+                                                              .build(),
+                                             new StringReader(data));
+        while (csv.readLine()) {
+            if (csv.isComment()) {
+                continue;
+            }
+
+            final List<String> row = new ArrayList<>();
+            while (csv.readField()) {
+                row.add(csv.toString());
+            }
+
+            if (skipEmptyRows && row.isEmpty()) {
+                continue;
+            }
+
+            // if (row.isEmpty()) row.add(""); // uncomment to fully match FastCSV
+
+            rows.add(row.toArray(String[]::new));
+        }
+
+        return rows;
+    }
+
+}


### PR DESCRIPTION
And another one!

picocsv is unusual because the API is very low-level. You have to build the rows yourself, and than includes a decision about how to handle empty rows - as a row of no cells, or a row of one empty cell. I have taken what seems like the most natural decision given the API, which is to treat such rows as having no cells. This is different to what FastCSV does, and not really compliant with the RFC 4180. There is a commented-out line which makes the implementation behave like FastCSV; perhaps this should be uncommented.

I'm not planning to add any more implementations after this.
